### PR TITLE
Add a Github Actions workflow to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          version-type: "strict"
+          otp-version: "28.1.1"
+          rebar3-version: "3.25.1"
+      - run: make all
+      - run: make test


### PR DESCRIPTION
I think it would be also good to make sure the `make all` step exits with an error code when some of the stdlib files couldn't be compiled, it seems currently only a warning is printed but the command still succeeds