### PR TITLE
Enforce @extern typed-head (E056) and no-body (E057); document FFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ cure check examples/protocols.cure
 
 - [Language Specification](docs/LANGUAGE_SPEC.md) -- syntax, keywords, operators, all constructs
 - [Type System](docs/TYPE_SYSTEM.md) -- bidirectional checking, refinement types, SMT verification
+- [FFI](docs/FFI.md) -- `@extern` foreign-function interface: module forms, effects, and lowering
 - [FSM Guide](docs/FSM_GUIDE.md) -- FSM definition, compilation, runtime, verification
 - [Supervision](docs/SUPERVISION.md) -- typed actors, `sup` containers, the Melquiades Operator, links and monitors (v0.25.0)
 - [Applications](docs/APP.md) -- `app` containers, `Cure.toml` `[application]` / `[release]` sections, the `cure release` subcommand, and `Std.App` (v0.26.0)

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -1,0 +1,218 @@
+# Foreign Function Interface (`@extern`)
+
+`@extern` is Cure's foreign-function interface. It lets a Cure function stand
+in for a function that lives outside Cure -- anything callable on the BEAM:
+Erlang/OTP modules (`:erlang`, `:io`, `:math`, ...), Elixir modules, AtomVM NIFs,
+or hand-written `Cure.*.Builtins` helpers.
+
+An `@extern` function is a **type-only signature**. You declare its name and
+types; the compiler trusts those types and lowers every call to a direct BEAM
+remote call. There is no Cure implementation to compile -- the implementation is
+the external function.
+
+```cure
+@extern(:erlang, :abs, 1)
+fn abs(x: Int) -> Int
+```
+
+Calling `abs(-42)` at runtime invokes `erlang:abs(-42)`.
+
+## Syntax
+
+```
+@extern(<module>, <function>, <arity>)
+<visibility?> fn <name>(<typed params>) -> <ReturnType>
+```
+
+The decorator takes exactly three arguments:
+
+| Argument | Meaning | Examples |
+|----------|---------|----------|
+| `<module>` | The target BEAM module | `:erlang`, `:io`, `:math`, `Elixir.Cure.FSM.Builtins` |
+| `<function>` | The target function name (an atom) | `:abs`, `:put_chars`, `:fsm_spawn` |
+| `<arity>` | The function's arity; must equal the number of parameters in the head | `0`, `1`, `2` |
+
+### Module names
+
+- **Erlang / OTP modules** are written as plain atoms: `:erlang`, `:io`,
+  `:math`, `:lists`, `:maps`.
+- **Elixir modules** are written with their fully qualified dotted path under
+  the `Elixir.` namespace: `Elixir.Cure.FSM.Builtins`, `Elixir.Enum`. The
+  parser converts the dotted path into the underlying module atom
+  (`:"Elixir.Cure.FSM.Builtins"`) for you.
+
+### Visibility
+
+`@extern` composes with the `local` keyword, exactly like a normal function, to
+make the FFI binding private to its module:
+
+```cure
+@extern(:erlang, :integer_to_binary, 1)
+local fn int_to_string(n: Int) -> String
+```
+
+## The two rules
+
+A foreign function is opaque to the compiler. Two invariants keep the FFI sound
+and honest; both are enforced at type-check time.
+
+### 1. The head must be fully typed (`E056`)
+
+Every parameter must carry a type annotation and a return type must be
+declared. The compiler cannot see the external implementation, so the declared
+types are the *only* contract it has. Without them the signature would silently
+default to `Any` and the type checker would be blind at every call site.
+
+```cure
+# rejected (E056): parameter `x` and the return type are missing
+@extern(:erlang, :abs, 1)
+fn abs(x)
+
+# ok
+@extern(:erlang, :abs, 1)
+fn abs(x: Int) -> Int
+```
+
+A zero-parameter extern still needs its return type:
+
+```cure
+@extern(:math, :pi, 0)
+fn pi() -> Float
+```
+
+### 2. The declaration must not have a body (`E057`)
+
+An `@extern` function has no Cure body. Codegen lowers it to a direct remote
+call, so anything you write as a body is dead code -- never compiled, never
+run. To stop that silent discard from misleading a reader, a body is an error.
+This applies to both body forms: a `= ...` body and a multi-clause `|`
+definition.
+
+```cure
+# rejected (E057): the `= x` body is ignored by codegen
+@extern(:erlang, :abs, 1)
+fn abs(x: Int) -> Int = x
+
+# rejected (E057): multi-clause bodies are ignored too
+@extern(:erlang, :abs, 1)
+fn abs(x: Int) -> Int
+  | 0 -> 0
+  | n -> n
+
+# ok
+@extern(:erlang, :abs, 1)
+fn abs(x: Int) -> Int
+```
+
+If you need local logic, write a normal function and call the extern from
+inside it:
+
+```cure
+@extern(:erlang, :abs, 1)
+fn raw_abs(x: Int) -> Int
+
+fn abs_or_zero(x: Int) -> Int =
+  pickup
+    x < -1000 -> 0
+    else      -> raw_abs(x)
+```
+
+Run `cure explain E056` or `cure explain E057` for the in-tool reference.
+
+## How it lowers
+
+An `@extern` function compiles to a thin wrapper whose body is a single remote
+call. For:
+
+```cure
+@extern(:erlang, :abs, 1)
+fn abs(x: Int) -> Int
+```
+
+codegen emits the Erlang equivalent of:
+
+```erlang
+abs(X) -> erlang:abs(X).
+```
+
+The parameters are passed straight through to the target function in order. The
+wrapper's arity is the number of parameters in the Cure head.
+
+## Type checking and trust
+
+The compiler **trusts** an `@extern` signature; it does not verify the declared
+types against the real external function (it cannot -- the function is outside
+Cure). At call sites, callers are checked against the declared head as if it
+were any other Cure function. The responsibility for matching the external
+function's true contract is yours.
+
+A practical consequence: keep the declared types as precise as the external
+function actually guarantees. An overly wide type (`Any`) propagates imprecision
+into every caller; an overly narrow one invites runtime surprises the checker
+will not catch.
+
+## Effects
+
+Calls through `@extern` carry an inferred effect, derived from the target
+module, so effect tracking still works across the FFI boundary:
+
+| Effect | Target modules |
+|--------|----------------|
+| `:io` | `:io`, `:file`, `:io_lib` |
+| `:state` | `:gen_server`, `:gen_statem`, `:ets`, `:persistent_term`, `:erlang` |
+| `:spawn` | `:proc_lib` |
+| `:extern` | any other module (the catch-all) |
+
+These feed Cure's effect inference the same way a native function's body would,
+so an effect annotation on a caller is checked against the effects its `@extern`
+calls introduce.
+
+## Examples
+
+Erlang stdlib:
+
+```cure
+@extern(:erlang, :abs, 1)
+fn abs(x: Int) -> Int
+
+@extern(:math, :sqrt, 1)
+fn sqrt(x: Float) -> Float
+
+@extern(:io, :put_chars, 1)
+fn print(s: String) -> Atom
+```
+
+Elixir / `Cure.*.Builtins` helpers (note the dotted `Elixir.` module path):
+
+```cure
+@extern(Elixir.Cure.FSM.Builtins, :fsm_spawn, 1)
+fn spawn(fsm_module: Atom) -> Pid
+
+@extern(Elixir.Cure.FSM.Builtins, :fsm_spawn_with_payload, 2)
+fn spawn_with_payload(fsm_module: Atom, payload: Any) -> Pid
+```
+
+The same name may be bound at several arities, each its own `@extern`:
+
+```cure
+@extern(Elixir.Cure.App.Builtins, :get_env, 2)
+fn get_env(name: Atom, key: Atom) -> Any
+
+@extern(Elixir.Cure.App.Builtins, :get_env, 3)
+fn get_env(name: Atom, key: Atom, default: Any) -> Any
+```
+
+## Runtime availability
+
+`@extern` is resolved at runtime by the BEAM, not at compile time by Cure. The
+target module and function must exist on the VM that runs the compiled code. A
+signature that compiles fine against `:re` or `:httpc`, for example, will still
+fail at runtime on a VM (such as AtomVM) that does not ship those modules. When
+targeting a constrained runtime, confirm the external function is present
+there.
+
+## Related
+
+- `docs/LANGUAGE_SPEC.md` -- the FFI section in the language reference.
+- `docs/STDLIB.md` -- the standard library, much of which is `@extern` wrappers.
+- `examples/ffi.cure` -- a minimal runnable FFI module.

--- a/docs/LANGUAGE_SPEC.md
+++ b/docs/LANGUAGE_SPEC.md
@@ -137,10 +137,29 @@ fn classify(x: Int) -> String
 
 ### FFI (Foreign Function Interface)
 
+`@extern(<module>, <function>, <arity>)` binds a Cure function to an external
+BEAM function. It is a **type-only signature**: the compiler trusts the declared
+types and lowers each call to a direct remote call.
+
 ```cure
 @extern(:erlang, :abs, 1)
 fn abs(x: Int) -> Int
 ```
+
+Two rules are enforced:
+
+- The head must be **fully typed** -- every parameter annotated and a return type
+  declared (`E056`). An untyped head would default to `Any` and defeat the type
+  checker.
+- The declaration must **not have a body** (`E057`). Codegen ignores any body,
+  so a `= ...` is dead code.
+
+Erlang/OTP modules are plain atoms (`:erlang`, `:io`); Elixir modules use their
+dotted `Elixir.` path (`Elixir.Cure.FSM.Builtins`). `@extern` composes with
+`local` for private bindings.
+
+See `docs/FFI.md` for the full guide (module forms, effects, lowering, and
+patterns).
 
 ## Types
 

--- a/lib/cure/compiler/errors.ex
+++ b/lib/cure/compiler/errors.ex
@@ -53,6 +53,16 @@ defmodule Cure.Compiler.Errors do
     format_diagnostic("error", "refinement violation (E090)", file, line, message)
   end
 
+  def format_error({:extern_untyped_head, message, meta}, file) do
+    line = Keyword.get(meta, :line, 0)
+    format_diagnostic("error", "@extern declaration missing a typed head (E056)", file, line, message)
+  end
+
+  def format_error({:extern_has_body, message, meta}, file) do
+    line = Keyword.get(meta, :line, 0)
+    format_diagnostic("error", "@extern declaration has a body (E057)", file, line, message)
+  end
+
   def format_error({:refinement_unknown, message, meta}, file) do
     line = Keyword.get(meta, :line, 0)
     format_diagnostic("warning", "refinement unknown (W091)", file, line, message)
@@ -1237,6 +1247,61 @@ defmodule Cure.Compiler.Errors do
 
     Fix: address the underlying systools error, then re-run
     `cure release`.
+    """,
+    "E056" => """
+    E056: @extern Declaration Missing a Typed Head
+
+    A function annotated with `@extern(:mod, :fun, arity)` is a type-only
+    foreign-function signature: the compiler does not see its implementation,
+    so it must trust the declared types and lower the call to a direct Erlang
+    remote call. That trust only holds if the head is fully typed -- every
+    parameter annotated and a return type declared. An untyped head would
+    silently default to `Any`, defeating the type checker at every call site.
+
+    Rejected:
+      @extern(:erlang, :abs, 1)
+      fn abs(x)                  # parameter `x` has no type, no return type
+
+    Fix: annotate the whole head.
+      @extern(:erlang, :abs, 1)
+      fn abs(x: Int) -> Int
+
+    A zero-parameter extern still needs its return type:
+      @extern(:math, :pi, 0)
+      fn pi() -> Float
+    """,
+    "E057" => """
+    E057: @extern Declaration Has a Body
+
+    A function annotated with `@extern` is a signature only. Codegen lowers it
+    to a direct remote call to the external function, so any body you write is
+    dead code -- it is never compiled or run. To stop that silent discard from
+    misleading readers, a body on an `@extern` function is an error. This covers
+    both a `= ...` body and a multi-clause `|` definition.
+
+    Rejected:
+      @extern(:erlang, :abs, 1)
+      fn abs(x: Int) -> Int = x  # the `= x` body is ignored by codegen
+
+    Also rejected (the clauses are ignored just the same):
+      @extern(:erlang, :abs, 1)
+      fn abs(x: Int) -> Int
+        | 0 -> 0
+        | n -> n
+
+    Fix: drop the body; keep only the typed head.
+      @extern(:erlang, :abs, 1)
+      fn abs(x: Int) -> Int
+
+    If you actually need local logic, write a normal function and call the
+    extern from inside it:
+      @extern(:erlang, :abs, 1)
+      fn raw_abs(x: Int) -> Int
+
+      fn abs_or_zero(x: Int) -> Int =
+        pickup
+          x < -1000 -> 0
+          else      -> raw_abs(x)
     """,
     "E063" => """
     E063: Parse Error (recovered)

--- a/lib/cure/types/checker.ex
+++ b/lib/cure/types/checker.ex
@@ -577,17 +577,25 @@ defmodule Cure.Types.Checker do
     declared_ret = if return_type_ast, do: resolve_with_env(env, return_type_ast), else: nil
 
     cond do
-      # @extern: trust declared types, classify effects
+      # @extern: a type-only FFI signature. Validate its shape, then trust the
+      # declared types and classify effects. The body, if any, is rejected here
+      # rather than silently discarded by codegen.
       extern != nil ->
-        extern_effects = Effects.classify_extern(extern)
+        case validate_extern_decl(params, return_type_ast, body, clauses, line) do
+          [] ->
+            extern_effects = Effects.classify_extern(extern)
 
-        if emit? do
-          ret = declared_ret || :any
-          Events.emit(:type_checker, :type_checked, {name, {:fun, [], ret}}, Events.meta(file, line))
-          Effects.emit_effects(name, extern_effects, file, line)
+            if emit? do
+              ret = declared_ret || :any
+              Events.emit(:type_checker, :type_checked, {name, {:fun, [], ret}}, Events.meta(file, line))
+              Effects.emit_effects(name, extern_effects, file, line)
+            end
+
+            []
+
+          errors ->
+            errors
         end
-
-        []
 
       # Multi-clause function
       clauses != nil ->
@@ -626,6 +634,57 @@ defmodule Cure.Types.Checker do
 
         type_errors
     end
+  end
+
+  # An @extern function is a type-only FFI signature: the compiler trusts its
+  # declared types and lowers the call to a direct Erlang remote call. Two
+  # invariants make that trust sound, and both are enforced here:
+  #
+  #   * E056 — the head must be fully typed (every parameter annotated and a
+  #     return type declared). Without types there is nothing to trust, and the
+  #     signature would otherwise default to `any`, defeating the type checker.
+  #   * E057 — the declaration must not have a body. Codegen ignores any body on
+  #     an @extern function, so a body is dead code that misleads the reader.
+  #     This covers both the `= ...` form (a non-empty `body`) and the
+  #     multi-clause `|` form (a non-nil `clauses`), which codegen discards too.
+  defp validate_extern_decl(params, return_type_ast, body, clauses, line) do
+    untyped_params =
+      params
+      |> Enum.filter(fn {:param, pmeta, _name} -> Keyword.get(pmeta, :type) == nil end)
+      |> Enum.map(fn {:param, _pmeta, pname} -> pname end)
+
+    missing =
+      []
+      |> then(fn acc ->
+        if untyped_params == [],
+          do: acc,
+          else: acc ++ ["parameter(s) " <> Enum.map_join(untyped_params, ", ", &"`#{&1}`")]
+      end)
+      |> then(fn acc -> if return_type_ast == nil, do: acc ++ ["a return type"], else: acc end)
+
+    head_errors =
+      if missing == [] do
+        []
+      else
+        [
+          {:extern_untyped_head,
+           "@extern declarations must have a fully typed head; add #{Enum.join(missing, " and ")}",
+           [line: line]}
+        ]
+      end
+
+    body_errors =
+      if body == [] and clauses == nil do
+        []
+      else
+        [
+          {:extern_has_body,
+           "@extern declarations are type-only signatures and must not have a body; remove the body (a `= ...` body or multi-clause `|` definition) -- the call is lowered directly to the external function",
+           [line: line]}
+        ]
+      end
+
+    head_errors ++ body_errors
   end
 
   defp maybe_check_declared_effects(nil, _inferred, _name, _file, _line), do: :ok

--- a/test/cure/compiler/errors_test.exs
+++ b/test/cure/compiler/errors_test.exs
@@ -27,6 +27,22 @@ defmodule Cure.Compiler.ErrorsTest do
       assert result =~ "expects 2 arguments"
     end
 
+    test "@extern untyped head (E056)" do
+      err = {:extern_untyped_head, "@extern declarations must have a fully typed head; add a return type", line: 2}
+      result = Errors.format_error(err, "ffi.cure")
+      assert result =~ "@extern declaration missing a typed head (E056)"
+      assert result =~ "ffi.cure:2"
+      assert result =~ "fully typed head"
+    end
+
+    test "@extern has a body (E057)" do
+      err = {:extern_has_body, "@extern declarations are type-only signatures and must not have a body", line: 3}
+      result = Errors.format_error(err, "ffi.cure")
+      assert result =~ "@extern declaration has a body (E057)"
+      assert result =~ "ffi.cure:3"
+      assert result =~ "must not have a body"
+    end
+
     test "wrapped type_error list" do
       errs =
         {:type_error,
@@ -122,6 +138,17 @@ defmodule Cure.Compiler.ErrorsTest do
       result = Errors.format_error(:something_unexpected, "test.cure")
       assert result =~ "compilation error"
       assert result =~ "something_unexpected"
+    end
+  end
+
+  describe "@extern catalog entries" do
+    for code <- ~w(E056 E057) do
+      test "explain/#{code}" do
+        assert {:ok, text} = Errors.explain(unquote(code))
+        assert text =~ unquote(code)
+        assert text =~ "@extern"
+        assert text =~ "Fix:"
+      end
     end
   end
 end

--- a/test/cure/types/checker_test.exs
+++ b/test/cure/types/checker_test.exs
@@ -327,6 +327,108 @@ defmodule Cure.Types.CheckerTest do
       assert {:ok, _} = Checker.check_module(ast, emit_events: false)
     end
 
+    test "@extern with no params and a typed return is valid" do
+      ast =
+        {:container, [container_type: :module, name: "M", line: 1],
+         [
+           {:function_def,
+            [
+              name: "pi",
+              params: [],
+              return_type: {:variable, [], "Float"},
+              visibility: :public,
+              arity: 0,
+              line: 1,
+              extern: {:math, :pi, 0}
+            ], []}
+         ]}
+
+      assert {:ok, _} = Checker.check_module(ast, emit_events: false)
+    end
+
+    test "@extern without a return type is rejected (E056)" do
+      ast =
+        {:container, [container_type: :module, name: "M", line: 1],
+         [
+           {:function_def,
+            [
+              name: "abs_val",
+              params: [{:param, [type: {:variable, [], "Int"}], "n"}],
+              visibility: :public,
+              arity: 1,
+              line: 1,
+              extern: {:erlang, :abs, 1}
+            ], []}
+         ]}
+
+      assert {:error, errors} = Checker.check_module(ast, emit_events: false)
+      assert Enum.any?(errors, &match?({:extern_untyped_head, _, _}, &1))
+    end
+
+    test "@extern with an untyped parameter is rejected (E056)" do
+      ast =
+        {:container, [container_type: :module, name: "M", line: 1],
+         [
+           {:function_def,
+            [
+              name: "abs_val",
+              params: [{:param, [], "n"}],
+              return_type: {:variable, [], "Int"},
+              visibility: :public,
+              arity: 1,
+              line: 1,
+              extern: {:erlang, :abs, 1}
+            ], []}
+         ]}
+
+      assert {:error, errors} = Checker.check_module(ast, emit_events: false)
+      assert Enum.any?(errors, &match?({:extern_untyped_head, _, _}, &1))
+    end
+
+    test "@extern with a body is rejected (E057)" do
+      ast =
+        {:container, [container_type: :module, name: "M", line: 1],
+         [
+           {:function_def,
+            [
+              name: "abs_val",
+              params: [{:param, [type: {:variable, [], "Int"}], "n"}],
+              return_type: {:variable, [], "Int"},
+              visibility: :public,
+              arity: 1,
+              line: 1,
+              extern: {:erlang, :abs, 1}
+            ], [{:variable, [scope: :local, line: 1], "n"}]}
+         ]}
+
+      assert {:error, errors} = Checker.check_module(ast, emit_events: false)
+      assert Enum.any?(errors, &match?({:extern_has_body, _, _}, &1))
+    end
+
+    test "@extern with multi-clause bodies is rejected (E057)" do
+      ast =
+        {:container, [container_type: :module, name: "M", line: 1],
+         [
+           {:function_def,
+            [
+              name: "abs_val",
+              params: [{:param, [type: {:variable, [], "Int"}], "n"}],
+              return_type: {:variable, [], "Int"},
+              visibility: :public,
+              arity: 1,
+              line: 1,
+              extern: {:erlang, :abs, 1},
+              clauses: [
+                %{params: [{:literal, [subtype: :integer], 0}], guard: nil, body: [{:literal, [subtype: :integer, line: 1], 0}]},
+                %{params: [{:variable, [scope: :local], "n"}], guard: nil, body: [{:variable, [scope: :local, line: 1], "n"}]}
+              ]
+            ], []}
+         ]}
+
+      assert {:error, errors} = Checker.check_module(ast, emit_events: false)
+      assert Enum.any?(errors, &match?({:extern_has_body, _, _}, &1))
+    end
+
     test "multi-clause function passes when clauses agree" do
       ast =
         {:container, [container_type: :module, name: "M", line: 1],


### PR DESCRIPTION
Fixes #27 