### PR TITLE
Fix double-UTF-8-encoding of non-ASCII bytes in the lexer

### DIFF
--- a/lib/cure/compiler/lexer.ex
+++ b/lib/cure/compiler/lexer.ex
@@ -755,7 +755,11 @@ defmodule Cure.Compiler.Lexer do
 
       c ->
         state = advance(state, 1)
-        lex_string_body(state, start_col, [<<c::utf8>> | acc])
+        # `c` is a raw source byte (peek/1 is :binary.at/2). The source is
+        # UTF-8, so appending the byte verbatim preserves multi-byte
+        # characters. Re-encoding here with <<c::utf8>> would double-encode
+        # every non-ASCII byte (e.g. E2 80 99 -> C3 A2 C2 80 C2 99).
+        lex_string_body(state, start_col, [<<c>> | acc])
     end
   end
 
@@ -1243,7 +1247,10 @@ defmodule Cure.Compiler.Lexer do
 
       c ->
         if pred.(c) do
-          consume_while(advance(state, 1), pred, [<<c::utf8>> | acc])
+          # `c` is a raw source byte; append it verbatim to preserve UTF-8.
+          # Re-encoding with <<c::utf8>> would double-encode non-ASCII bytes
+          # in comments and doc comments (whose predicate accepts any byte).
+          consume_while(advance(state, 1), pred, [<<c>> | acc])
         else
           {IO.iodata_to_binary(Enum.reverse(acc)), state}
         end

--- a/test/cure/compiler/lexer_test.exs
+++ b/test/cure/compiler/lexer_test.exs
@@ -137,6 +137,27 @@ defmodule Cure.Compiler.LexerTest do
       assert [%Token{type: :string, value: ""}, _] = lex!(~s(""))
     end
 
+    test "non-ASCII characters keep their UTF-8 bytes (regression: were double-encoded)" do
+      # U+2019 RIGHT SINGLE QUOTATION MARK, UTF-8 <<0xE2, 0x80, 0x99>>.
+      # The lexer read the source byte-by-byte and re-encoded each byte with
+      # <<c::utf8>>, turning E2 80 99 into C3 A2 C2 80 C2 99 (mojibake).
+      [%Token{type: :string, value: v1}, _] = lex!(~s("Dusty’s Place"))
+      assert v1 == "Dusty’s Place"
+      assert byte_size(v1) == byte_size("Dusty’s Place")
+
+      # A two-byte char as well: U+00E9 é, UTF-8 <<0xC3, 0xA9>>.
+      [%Token{type: :string, value: v2}, _] = lex!(~s("café"))
+      assert v2 == "café"
+      assert byte_size(v2) == 5
+    end
+
+    test "doc comments keep their UTF-8 bytes (same consume_while path)" do
+      # The same byte-vs-utf8 bug also affected comment/doc-comment text,
+      # which feeds `cure doc`.
+      [%Token{type: :doc_comment, value: text} | _] = lex!("## café’s\n")
+      assert text == "café’s"
+    end
+
     test "unterminated string returns error" do
       assert {:error, {:unterminated_string, 1, 1}} = Lexer.tokenize(~s("hello), emit_events: false)
     end


### PR DESCRIPTION
The lexer reads source by byte (`peek/1` is `:binary.at/2`) but built token text with `<<c::utf8>>`, which treats each raw byte as a codepoint and UTF-8-encodes it. For any non-ASCII byte this double-encodes: a curly apostrophe (U+2019, UTF-8 `E2 80 99`) in a string literal became `C3 A2 C2 80 C2 99`. ASCII bytes (< 128) encode to themselves, so the bug only surfaced with non-ASCII content.